### PR TITLE
feat: use on_events config for custom eventing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ require('nvim-biscuits').setup({
 EOF
 ```
 
+## Configuration (Custom events)
+
+If you want to decorate only on specific vim events you can use the `on_events` cofnig option. It is a string that takes in a comma separated list of vim autocmd events ([http://vimdoc.sourceforge.net/htmldoc/autocmd.html#autocmd-events](http://vimdoc.sourceforge.net/htmldoc/autocmd.html#autocmd-events))
+
+This example only updates the biscuits when leaving insert mode or hold the cursor in one place for long enough.
+
+```lua
+lua <<EOF
+require('nvim-biscuits').setup({
+  on_events = 'InsertLeave,CursorHoldI'
+})
+EOF
+```
+
 ## Configuration (Virtual Text Color)
 
 You can configure the `highlight` group in your init.vim:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This example only updates the biscuits when leaving insert mode or hold the curs
 ```lua
 lua <<EOF
 require('nvim-biscuits').setup({
-  on_events = 'InsertLeave,CursorHoldI'
+  on_events = { 'InsertLeave', 'CursorHoldI' }
 })
 EOF
 ```

--- a/lua/nvim-biscuits/config.lua
+++ b/lua/nvim-biscuits/config.lua
@@ -4,7 +4,9 @@ config.default_config = function ()
   return {
     min_distance = 5,
     max_length = 80,
-    prefix_string = " // "
+    prefix_string = " // ",
+    -- on_events example: InsertLeave,CursorHoldI
+    on_events = ""
   }
 end
 

--- a/lua/nvim-biscuits/config.lua
+++ b/lua/nvim-biscuits/config.lua
@@ -5,8 +5,8 @@ config.default_config = function ()
     min_distance = 5,
     max_length = 80,
     prefix_string = " // ",
-    -- on_events example: InsertLeave,CursorHoldI
-    on_events = ""
+    -- on_events example: { "InsertLeave", "CursorHoldI" }
+    on_events = {}
   }
 end
 

--- a/lua/nvim-biscuits/dev.lua
+++ b/lua/nvim-biscuits/dev.lua
@@ -11,4 +11,10 @@ dev.console_log = function (the_string)
   end
 end
 
+dev.clear_log = function ()
+  if debug then
+    Path:new(debug_path):write('', 'w')
+  end
+end
+
 return dev

--- a/lua/nvim-biscuits/init.lua
+++ b/lua/nvim-biscuits/init.lua
@@ -19,6 +19,9 @@ local make_biscuit_hl_group = function(lang)
 end
 
 nvim_biscuits.decorate_nodes = function (bufnr, lang)
+
+  utils.console_log("decorating nodes")
+
   local parser = ts_parsers.get_parser(bufnr, lang)
 
   if parser == nil then
@@ -42,7 +45,7 @@ nvim_biscuits.decorate_nodes = function (bufnr, lang)
 
       local lines = vim.api.nvim_buf_get_lines(bufnr, start_line, start_line+1, false)
 
-      local text = lines[1] or ''
+      local text = lines[1]
 
       text = utils.trim(text)
 
@@ -127,15 +130,19 @@ nvim_biscuits.BufferAttach = function(bufnr)
     nvim_biscuits.decorate_nodes(bufnr, lang)
   end
 
+
   vim.cmd("highlight default link " .. make_biscuit_hl_group(lang) .. " BiscuitColor")
 
-  if final_config.on_insert_event then
+  -- we need to fire once at the very start
+  nvim_biscuits.decorate_nodes(bufnr, lang)
+
+  if final_config.on_events ~= "" then
     vim.api.nvim_exec(string.format([[
       augroup Biscuits
         au!
-        au InsertLeave,CursorHoldI <buffer=%s> :lua require("nvim-biscuits").decorate_nodes(%s, "%s")
+        au %s <buffer=%s> :lua require("nvim-biscuits").decorate_nodes(%s, "%s")
       augroup END
-    ]], bufnr, bufnr, lang), false)
+    ]],final_config.on_events, bufnr, bufnr, lang), false)
   else
     vim.api.nvim_buf_attach(bufnr, false, {
       on_lines = on_lines,

--- a/lua/nvim-biscuits/init.lua
+++ b/lua/nvim-biscuits/init.lua
@@ -136,13 +136,22 @@ nvim_biscuits.BufferAttach = function(bufnr)
   -- we need to fire once at the very start
   nvim_biscuits.decorate_nodes(bufnr, lang)
 
-  if final_config.on_events ~= "" then
-    vim.api.nvim_exec(string.format([[
-      augroup Biscuits
-        au!
-        au %s <buffer=%s> :lua require("nvim-biscuits").decorate_nodes(%s, "%s")
-      augroup END
-    ]],final_config.on_events, bufnr, bufnr, lang), false)
+  local on_events = table.concat(final_config.on_events, ',')
+  if on_events ~= "" then
+    vim.api.nvim_exec(
+      string.format([[
+          augroup Biscuits
+            au!
+            au %s <buffer=%s> :lua require("nvim-biscuits").decorate_nodes(%s, "%s")
+          augroup END
+        ]],
+        on_events,
+        bufnr,
+        bufnr,
+        lang
+      ),
+      false
+    )
   else
     vim.api.nvim_buf_attach(bufnr, false, {
       on_lines = on_lines,

--- a/lua/nvim-biscuits/utils.lua
+++ b/lua/nvim-biscuits/utils.lua
@@ -20,6 +20,11 @@ utils.merge_arrays = function(a, b)
 end
 
 utils.merge_tables = function(t1, t2)
+  for k,v in pairs(t2) do t1[k] = v end
+  return t1
+end
+
+utils.merge_tables_deep = function(t1, t2)
   for k,v in pairs(t2) do
       if type(v) == "table" then
           if type(t1[k] or false) == "table" then

--- a/lua/nvim-biscuits/utils.lua
+++ b/lua/nvim-biscuits/utils.lua
@@ -9,6 +9,10 @@ utils.console_log = function (the_string)
   -- dev.console_log(the_string)
 end
 
+utils.clear_log = function ()
+  --  dev.clear_log()
+end
+
 utils.merge_arrays = function(a, b)
   local result = {unpack(a)}
   table.move(b, 1, #b, #result + 1, result)
@@ -32,12 +36,6 @@ end
 
 utils.trim = function(s)
   return s:match'^()%s*$' and '' or s:match'^%s*(.*%S)'
-end
-
-utils.clear_log = function ()
-  if debug == true then
-    Path:new(debug_path):write('', 'w')
-  end
 end
 
 return utils

--- a/plugin/nvim-biscuits.vim
+++ b/plugin/nvim-biscuits.vim
@@ -1,7 +1,6 @@
 :lua require('nvim-biscuits')
 
 highlight default BiscuitColor ctermfg=gray
-highlight default link BiscuitColorRust BiscuitColor
 
 augroup NVIM_BISCUITS
     autocmd!


### PR DESCRIPTION
This adds a config option for custom event listening.

`on_events` is the config option and it takes a comma separated list of vim events. (no spaces)