### PR TITLE
fix: trim() return empty string when 's' is nil

### DIFF
--- a/lua/nvim-biscuits/utils.lua
+++ b/lua/nvim-biscuits/utils.lua
@@ -40,6 +40,7 @@ utils.merge_tables_deep = function(t1, t2)
 end
 
 utils.trim = function(s)
+  if s == nil then return '' end
   return s:match'^()%s*$' and '' or s:match'^%s*(.*%S)'
 end
 


### PR DESCRIPTION
In reference to issue #9, this makes sure to return an empty string if 's' was `nil`. No need to go thru the trim logic as at that point 's' will be a `nil` value.