### PR TITLE
fix: only handle elements in html files

### DIFF
--- a/lua/nvim-biscuits/init.lua
+++ b/lua/nvim-biscuits/init.lua
@@ -20,7 +20,7 @@ local make_biscuit_hl_group_name =
 nvim_biscuits.decorate_nodes = function(bufnr, lang)
     if config.get_language_config(final_config, lang, "disabled") then return end
 
-    utils.console_log("decorating nodes")
+    utils.console_log("decorating nodes for " .. lang)
 
     local parser = ts_parsers.get_parser(bufnr, lang)
 
@@ -121,11 +121,10 @@ nvim_biscuits.decorate_nodes = function(bufnr, lang)
                     vim.api.nvim_buf_clear_namespace(bufnr,
                                                      biscuit_highlight_group,
                                                      end_line, end_line + 1)
-                    vim.api.nvim_buf_set_extmark(bufnr, biscuit_highlight_group, end_line, 0, {
+                    vim.api.nvim_buf_set_extmark(bufnr, biscuit_highlight_group,
+                                                 end_line, 0, {
                         virt_text_pos = "eol",
-                        virt_text = {
-                            {text, biscuit_highlight_group_name}
-                        },
+                        virt_text = {{text, biscuit_highlight_group_name}},
                         hl_mode = "combine"
                     })
                 end

--- a/lua/nvim-biscuits/languages.lua
+++ b/lua/nvim-biscuits/languages.lua
@@ -2,6 +2,7 @@ local html = require("nvim-biscuits.languages.html")
 local vue = require("nvim-biscuits.languages.vue")
 local javascript = require("nvim-biscuits.languages.javascript")
 local python = require("nvim-biscuits.languages.python")
+local utils = require("nvim-biscuits.utils")
 
 local languages = {}
 
@@ -14,6 +15,7 @@ local handled_languages = {
 
 languages.should_decorate = function(language_name, ts_node, text)
     local language = handled_languages[language_name]
+
     if language == nil then return true end
 
     return language.should_decorate(ts_node, text)

--- a/lua/nvim-biscuits/languages/html.lua
+++ b/lua/nvim-biscuits/languages/html.lua
@@ -30,12 +30,18 @@ language.should_decorate = function(ts_node, text, bufnr)
         if text == end_string then return false end
     end
 
-    if ts_node:type() == "element" then return true end
+    local elements = {
+        "element", "jsx_element", "self_closing_element",
+        "jsx_self_closing_element"
+    }
+
+    if utils.list_contains(elements, ts_node:type()) then return true end
 
     return false
 end
 
 language.transform_text = function(ts_node, text, bufnr)
+
     local end_string = get_node_last_line(ts_node)
     end_string = string.gsub(end_string, '/', '')
     end_string = string.gsub(end_string, '>', '')
@@ -45,7 +51,20 @@ language.transform_text = function(ts_node, text, bufnr)
     text = string.gsub(text, '>', '')
     text = string.gsub(text, '  ', ' ')
 
-    return utils.trim(text)
+    text = utils.trim(text)
+
+    if text == '<p className="p0"' then
+        local type = ts_node:type()
+        local parent = ts_node:parent()
+        utils.console_log("-----------------------------------------------")
+        utils.console_log("HTML type: " .. type)
+        utils.console_log("HTML Parent type: " .. parent:type())
+        utils.console_log("HTML text: " .. text)
+        -- utils.console_log("JS name: " .. ts_node:named())
+        -- utils.console_log("JS sexpr: " .. ts_node:sexpr())
+        utils.console_log("-----------------------------------------------")
+    end
+    return text
 end
 
 return language

--- a/lua/nvim-biscuits/languages/html.lua
+++ b/lua/nvim-biscuits/languages/html.lua
@@ -29,7 +29,10 @@ language.should_decorate = function(ts_node, text, bufnr)
 
         if text == end_string then return false end
     end
-    return true
+
+    if ts_node:type() == "element" then return true end
+
+    return false
 end
 
 language.transform_text = function(ts_node, text, bufnr)

--- a/lua/nvim-biscuits/languages/javascript.lua
+++ b/lua/nvim-biscuits/languages/javascript.lua
@@ -5,7 +5,23 @@ local html = require("nvim-biscuits.languages.html")
 local language = {}
 
 language.should_decorate = function(ts_node, text, bufnr)
-    local should_decorate = html.should_decorate(ts_node, text)
+    local type = ts_node:type()
+    local elements = {"jsx_element", "jsx_self_closing_element"}
+
+    local should_decorate = true
+    if utils.list_contains(elements, type) then
+        should_decorate = html.should_decorate(ts_node, text)
+    end
+
+    local ignored_element_types = {
+        -- "identifier"
+        "jsx_text"
+    }
+
+    if utils.list_contains(ignored_element_types, type) then
+        should_decorate = false
+    end
+
     return should_decorate
 end
 

--- a/lua/nvim-biscuits/utils.lua
+++ b/lua/nvim-biscuits/utils.lua
@@ -41,4 +41,12 @@ utils.trim = function(s)
     return s:match '^()%s*$' and '' or s:match '^%s*(.*%S)'
 end
 
+utils.list_contains = function(list, needle)
+    for index, value in ipairs(list) do
+        if value == needle then return true; end
+    end
+
+    return false;
+end
+
 return utils


### PR DESCRIPTION
After some fiddling, I discovered some odd behavior and tracked it down to not being selective about the node type to handle in HTML.

This cleans up one example output I have, but I will need to test some more.

Please pull it down and test on .html files if you can. Thanks