### PR TITLE
fix: non-silent toggle keybind

### DIFF
--- a/lua/nvim-biscuits/init.lua
+++ b/lua/nvim-biscuits/init.lua
@@ -170,7 +170,7 @@ nvim_biscuits.BufferAttach = function(bufnr)
     if toggle_keybind ~= nil and
         not config.get_language_config(final_config, lang, "disabled") then
         vim.api.nvim_set_keymap("n", toggle_keybind,
-                                ":lua require('nvim-biscuits').toggle_biscuits()<CR>",
+                                "<Cmd>lua require('nvim-biscuits').toggle_biscuits()<CR>",
                                 {noremap = false})
     end
 

--- a/lua/nvim-biscuits/init.lua
+++ b/lua/nvim-biscuits/init.lua
@@ -171,7 +171,7 @@ nvim_biscuits.BufferAttach = function(bufnr)
         not config.get_language_config(final_config, lang, "disabled") then
         vim.api.nvim_set_keymap("n", toggle_keybind,
                                 "<Cmd>lua require('nvim-biscuits').toggle_biscuits()<CR>",
-                                {noremap = false})
+                                { noremap = false, desc = "toggle biscuits" })
     end
 
     local on_lines = function() nvim_biscuits.decorate_nodes(bufnr, lang) end


### PR DESCRIPTION
Keymap for `toggle_keybind` displays the following unnecessary message by default every time. This fix removes it :))

![image](https://user-images.githubusercontent.com/62098008/185100236-28de4824-3eec-443b-80c4-a696f211b213.png)
