### PR TITLE
fix: use nvim-treesitter define_modules to attach/detach to buffers

### DIFF
--- a/plugin/nvim-biscuits.vim
+++ b/plugin/nvim-biscuits.vim
@@ -2,7 +2,3 @@
 
 highlight default BiscuitColor ctermfg=gray guifg=gray
 
-augroup NVIM_BISCUITS
-    autocmd!
-    autocmd BufEnter * :lua require('nvim-biscuits').BufferAttach()
-augroup END


### PR DESCRIPTION
Fixes #41 

By changing the way nvim-biscuits attaches to the buffer (using the nvim-treesitter define_modules functionality)
it seems to have resolved the issue I was experiencing when opening a file via telescope.

I suspect that the BufEnter autocmd was triggering too early causing the buffer to not complete have been registered with treesitter and so the language was empty string.