### PR TITLE
chore: `nvim-treesitter.ts_utils.get_node_range` -> `vim.treesitter.get_node_range`

### DIFF
--- a/lua/nvim-biscuits/init.lua
+++ b/lua/nvim-biscuits/init.lua
@@ -48,7 +48,7 @@ nvim_biscuits.decorate_nodes = function(bufnr, lang)
                                           ts_utils.get_named_children(node))
 
             local start_line, start_col, end_line, end_col =
-                ts_utils.get_node_range(node)
+                vim.treesitter.get_node_range(node)
 
             local lines = vim.api.nvim_buf_get_lines(bufnr, start_line,
                                                      start_line + 1, false)

--- a/lua/nvim-biscuits/languages/html.lua
+++ b/lua/nvim-biscuits/languages/html.lua
@@ -1,4 +1,3 @@
-local ts_utils = require('nvim-treesitter.ts_utils')
 local utils = require("nvim-biscuits.utils")
 
 local language = {}
@@ -7,7 +6,7 @@ local function get_node_last_line(ts_node)
     local bufnr = vim.api.nvim_get_current_buf()
 
     local start_row, start_col, end_row, end_col =
-        ts_utils.get_node_range(ts_node)
+        vim.treesitter.get_node_range(ts_node)
 
     local end_lines = vim.api.nvim_buf_get_lines(bufnr, end_row, end_row + 1,
                                                  false)

--- a/lua/nvim-biscuits/languages/python.lua
+++ b/lua/nvim-biscuits/languages/python.lua
@@ -1,4 +1,3 @@
-local ts_utils = require('nvim-treesitter.ts_utils')
 local utils = require("nvim-biscuits.utils")
 
 local language = {}
@@ -10,9 +9,9 @@ end
 
 language.transform_text = function(ts_node, text, bufnr)
     local start_line, start_col, end_line, end_col =
-        ts_utils.get_node_range(ts_node)
+        vim.treesitter.get_node_range(ts_node)
     local parent_start_line, parent_start_col, parent_end_line, parent_end_col =
-        ts_utils.get_node_range(ts_node:parent())
+        vim.treesitter.get_node_range(ts_node:parent())
     if parent_start_line == start_line - 1 then
         start_line = parent_start_line
         start_col = parent_start_col


### PR DESCRIPTION
- 'nvim-treesitter.ts_utils.get_node_range' has been deprecated in favor of 'vim.treesitter.get_node_range'